### PR TITLE
setcookie now uses  rcube_utils::setcookie

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,6 @@
+[2015-05-23 01:11:00] Gianluca Giacometti
+    Fixed primary key in postgresql table
+    Changed css
+    Used function  rcube_utils::setcookie  to set cookies
+    Deleted the check of $_COOKIE after intert/delete: it's not possible to check at that time and log file records a wrong error of cookie unset
+

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -3,7 +3,7 @@
 // PERSISTENT LOGIN / REMEMBER ME
 // ----------------------------------
 
-// Time until the peristent login cookie invalidates (in milliseconds; 60*60*24*3 = 3 days)
+// Time until the peristent login cookie invalidates (in seconds; 60*60*24*3 = 3 days)
 $rcmail_config['ifpl_login_expire'] = 60*60*24*3;
 
 // The name of the persistent login cookie.

--- a/persistent_login.css
+++ b/persistent_login.css
@@ -1,6 +1,8 @@
 #ifplcontainer {
 	border: 0 solid #999;
-	text-align:center;
+	color: #cecece;
+	text-align: center;
+	text-shadow: 0 1px 1px black;
 }
 
 #ifplcontainer div {
@@ -14,10 +16,14 @@
 
 #ifplcontainer p {
 	display:none;
+	background: none repeat scroll 0 0 #fff;
 	margin: 5px 0 0 0;
 	font-size:0.9em;
 }
 
 #ifplcontainer p {
+	border-radius: 4px;
 	color: #990000;
+	padding: 5px;
+	text-shadow: none;
 }

--- a/persistent_login.php
+++ b/persistent_login.php
@@ -321,7 +321,7 @@ class persistent_login extends rcube_plugin
 				$auth_token, $sql_expires, $user_id, $user_name, $user_password, $host);
 
 			// set token as cookie.
-			if (!self::set_cookie($this->cookie_name, $crypt_token, time() + $this->cookie_expire_time)) {
+			if (!self::set_cookie($this->cookie_name, $crypt_token, $ts_expires)) {
 				error_log('unable to set persistent login cookie for user "'.$rcmail->user->data['username'].'"');
 			}
 		}
@@ -387,7 +387,6 @@ class persistent_login extends rcube_plugin
 	
 	/**
 	 * sets a cookie.
-	 * @todo for some reason using rcmail::setcookie() doesn't work.
 	 *
 	 * @param $name
 	 * @param $value
@@ -396,8 +395,8 @@ class persistent_login extends rcube_plugin
 	 */
 	function set_cookie($name, $value, $exp = 0)
 	{
-		rcmail::get_instance()->setcookie($name, $value, $exp);
-		return isset($_COOKIE[$name]);
+		rcube_utils::setcookie($name, $value, $exp);
+		return true;
 	}
 	
 	/**
@@ -411,6 +410,7 @@ class persistent_login extends rcube_plugin
 		if (headers_sent()) {
 			return false;
 		}
-		return rcmail::get_instance()->setcookie($name, "", time() - 60);
+		rcube_utils::setcookie($name, "", time() - 60);
+		return true;
 	}
 }

--- a/sql/postgres.sql
+++ b/sql/postgres.sql
@@ -1,4 +1,12 @@
+CREATE SEQUENCE auth_tokens_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MAXVALUE
+    NO MINVALUE
+    CACHE 1;
+
 CREATE TABLE auth_tokens (
+	id integer DEFAULT nextval('auth_tokens_seq'::text) PRIMARY KEY,
         token varchar(128) DEFAULT '' NOT NULL,
         expires timestamp with time zone NOT NULL,      
         user_id integer NOT NULL


### PR DESCRIPTION
Hi,
I changed the setcookie function to  rcube_utils::setcookie
I made small changes to clean the code
NOTE:
after setcookie the $_COOKIE array is not updated so it's not possible to check that way if the cookie was correctly inserted; I just added return true to avoid log file to record wrong messages